### PR TITLE
Retrieve all data at end of measurement

### DIFF
--- a/easy_biologic/base_programs.py
+++ b/easy_biologic/base_programs.py
@@ -205,6 +205,7 @@ import time
 from datetime import datetime as dt
 import asyncio
 from collections import namedtuple
+import logging
 
 from . import BiologicProgram
 from .program import CallBack
@@ -772,7 +773,7 @@ class CP( BiologicProgram ):
             # transform to dictionary if needed
             currents = { ch: currents for ch in self.channels }
 
-        if ( durations is not None ) and ( not isinstance( voltages, dict ) ):
+        if ( durations is not None ) and ( not isinstance( durations, dict ) ):
             # transform to dictionary if needed
             durations = { ch: durations for ch in self.channels }
 
@@ -813,7 +814,7 @@ class CP( BiologicProgram ):
         :param currents: List of currents.
         :returns: ec_lib.IRange corresponding to largest current.
         """
-        i_max = max( abs( currents ) )
+        i_max = max( [ abs(c) for c in currents ] )
 
         if i_max < 100e-12:
             i_range = ecl.IRange.p100

--- a/easy_biologic/program.py
+++ b/easy_biologic/program.py
@@ -286,12 +286,12 @@ class BiologicProgram( ABC ):
 
         states = {}
         for ch in channels:
-            info = self.device.channel_info( channel )
+            info = self.device.channel_info( ch )
             states[ ch ] = ecl.ChannelState( info.State )
 
         if single_ch:
             # single channel provided
-            return states[ channel ]
+            return states[ ch ]
 
         return states
 
@@ -588,6 +588,12 @@ class BiologicProgram( ABC ):
                 done = ( ecl.ChannelState( ch_segment.values.State  ) is ecl.ChannelState.STOP )
                 complete[ ch ] = done
                 if done:
+                    # Get all remaining data from channel
+                    count = len(segments[ch].data)
+                    while count > 0:
+                        segment = await self._retrieve_data_segment(ch)
+                        count = len(segment.data)
+                        
                     logging.debug( f'Channel {ch} complete.' )
 
 


### PR DESCRIPTION
This is a minor modification to ensure that all data is collected from the queue when a channel is stopped. This is especially important for measurements with fast sample rates (e.g. CP or CA). If you'd like to see this done differently, I'm open to suggestions. Also includes a few minor corrections to base_programs.